### PR TITLE
Initialize the buzzer to high, to stop beeping on boot

### DIFF
--- a/components/ifan/ifan.cpp
+++ b/components/ifan/ifan.cpp
@@ -18,6 +18,9 @@ void IFan::setup() {
   pinMode(relay_2, 0x01);
   pinMode(relay_3, 0x01);
 
+  //Initialize buzzer to stop errant beeping due to non-initialized pin
+  digitalWrite(buzzer, HIGH);
+
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->apply(*this);


### PR DESCRIPTION
It seems the pin could be left LOW under some conditions. Or the micro
would leave the pin floating which would cause a constant beep. This will
make us always initialize it to HIGH on boot, regardless of whether the
buzzer is enabled.