### PR TITLE
Update relay logic to match Tasmota and Factory Configuration

### DIFF
--- a/components/ifan/ifan.cpp
+++ b/components/ifan/ifan.cpp
@@ -80,13 +80,13 @@ void IFan::set_low() {
   beep();
 }
 void IFan::set_med() {
-  digitalWrite(relay_1, LOW);
+  digitalWrite(relay_1, HIGH);
   digitalWrite(relay_2, HIGH);
   digitalWrite(relay_3, LOW);
   beep(2);
 }
 void IFan::set_high() {
-  digitalWrite(relay_1, LOW);
+  digitalWrite(relay_1, HIGH);
   digitalWrite(relay_2, LOW);
   digitalWrite(relay_3, HIGH);
 


### PR DESCRIPTION
It feels to me like "Mid" is way to slow on this fan. When compaired to stock SONoff and Tasmota firmware, I noticed use a different logic in the relays. This pull request edits them to match, which made things a lot better in my local repo.