### PR TITLE
Set relay1 high on speed medium

### DIFF
--- a/components/ifan/fan.py
+++ b/components/ifan/fan.py
@@ -8,7 +8,7 @@ from esphome.const import (
     CONF_OUTPUT_ID,
     CONF_ID,
 )
-from esphome.core import  coroutine_with_priority
+from esphome.core import coroutine_with_priority
 
 DEPENDENCIES = ['uart']
 
@@ -19,33 +19,38 @@ ifan_ns = cg.esphome_ns.namespace("ifan")
 IFan = ifan_ns.class_("IFan", cg.Component, fan.Fan, uart.UARTDevice)
 CycleSpeedAction = ifan_ns.class_("CycleSpeedAction", automation.Action)
 
+# Fixed CONFIG_SCHEMA with proper dictionary syntax
 CONFIG_SCHEMA = (
     fan.fan_schema(IFan)
-    .extend(cv.Optional(BUZZER_ENABLE, default=True): cv.boolean)
-    .extend(cv.Optional(REMOTE_ENABLE, default=True): cv.boolean)
-    .extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
+    .extend({
+        cv.Optional(BUZZER_ENABLE, default=True): cv.boolean,
+        cv.Optional(REMOTE_ENABLE, default=True): cv.boolean,
+    })
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
 )
+
 FAN_ACTION_SCHEMA = maybe_simple_id(
     {
         cv.Required(CONF_ID): cv.use_id(IFan),
     }
 )
+
 @automation.register_action("ifan.cycle_speed", CycleSpeedAction, FAN_ACTION_SCHEMA)
 async def fan_cycle_speed_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 @coroutine_with_priority(100.0)
-
 async def to_code(config):
     cg.add_define("USE_FAN")
     var = await fan.new_fan(config)
     cg.add(var.set_buzzer_enable(config[BUZZER_ENABLE]))
     cg.add(var.set_remote_enable(config[REMOTE_ENABLE]))
-    if REMOTE_ENABLE in config:
-        #await cg.register_component(var, config)
-        await uart.register_uart_device(var, config)
-    await cg.register_component(var, config)
-
     
+    # Register UART device if remote is enabled
+    if REMOTE_ENABLE in config:
+        await uart.register_uart_device(var, config)
+    
+    await cg.register_component(var, config)
     cg.add_global(ifan_ns.using)

--- a/components/ifan/fan.py
+++ b/components/ifan/fan.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import fan,uart
+from esphome.components import fan, uart
 from esphome import automation
 from esphome.automation import maybe_simple_id
 
@@ -19,12 +19,10 @@ ifan_ns = cg.esphome_ns.namespace("ifan")
 IFan = ifan_ns.class_("IFan", cg.Component, fan.Fan, uart.UARTDevice)
 CycleSpeedAction = ifan_ns.class_("CycleSpeedAction", automation.Action)
 
-CONFIG_SCHEMA = fan.FAN_SCHEMA.extend(
-    {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(IFan),
-        cv.Optional(BUZZER_ENABLE, default=True): cv.boolean,
-        cv.Optional(REMOTE_ENABLE, default=True): cv.boolean,
-    }
+CONFIG_SCHEMA = (
+    fan.fan_schema(IFan)
+    .extend(cv.Optional(BUZZER_ENABLE, default=True): cv.boolean)
+    .extend(cv.Optional(REMOTE_ENABLE, default=True): cv.boolean)
 ).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
 FAN_ACTION_SCHEMA = maybe_simple_id(
     {
@@ -40,15 +38,13 @@ async def fan_cycle_speed_to_code(config, action_id, template_arg, args):
 
 async def to_code(config):
     cg.add_define("USE_FAN")
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    var = await fan.new_fan(config)
     cg.add(var.set_buzzer_enable(config[BUZZER_ENABLE]))
     cg.add(var.set_remote_enable(config[REMOTE_ENABLE]))
     if REMOTE_ENABLE in config:
         #await cg.register_component(var, config)
         await uart.register_uart_device(var, config)
     await cg.register_component(var, config)
-
-    await fan.register_fan(var, config)
 
     
     cg.add_global(ifan_ns.using)

--- a/components/ifan/fan.py
+++ b/components/ifan/fan.py
@@ -23,7 +23,8 @@ CONFIG_SCHEMA = (
     fan.fan_schema(IFan)
     .extend(cv.Optional(BUZZER_ENABLE, default=True): cv.boolean)
     .extend(cv.Optional(REMOTE_ENABLE, default=True): cv.boolean)
-).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
+)
 FAN_ACTION_SCHEMA = maybe_simple_id(
     {
         cv.Required(CONF_ID): cv.use_id(IFan),

--- a/components/ifan/ifan.cpp
+++ b/components/ifan/ifan.cpp
@@ -80,7 +80,7 @@ void IFan::set_low() {
   beep();
 }
 void IFan::set_med() {
-  digitalWrite(relay_1, LOW);
+  digitalWrite(relay_1, HIGH);
   digitalWrite(relay_2, HIGH);
   digitalWrite(relay_3, LOW);
   beep(2);

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -15,6 +15,7 @@ CONF_ON_BUZZER = "on_buzzer"
 
 # Reverted to the original working schema - cv.COMPONENT_SCHEMA without fan.fan_schema
 CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend({
+    cv.GenerateID(): cv.declare_id(IFan04),  # Add the ID field
     cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
     cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
     cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.components import fan, uart
 
 DEPENDENCIES = ['uart']
 
@@ -14,8 +13,8 @@ CONF_ON_FAN = "on_fan"
 CONF_ON_LIGHT = "on_light"
 CONF_ON_BUZZER = "on_buzzer"
 
-CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend({
-    cv.GenerateID(): cv.declare_id(IFan04),
+CONFIG_SCHEMA = ({
+    fan.fan_schema(IFan04)
     cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
     cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
     cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),
@@ -23,7 +22,7 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend({
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await fan.new_fan(config)
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import fan, uart
+from esphome.components import uart
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ['uart']
-
 
 ifan04_ns = cg.esphome_ns.namespace('ifan04')
 IFan04 = ifan04_ns.class_('IFan04', cg.Component, uart.UARTDevice)
@@ -13,23 +13,17 @@ CONF_ON_FAN = "on_fan"
 CONF_ON_LIGHT = "on_light"
 CONF_ON_BUZZER = "on_buzzer"
 
-CONFIG_SCHEMA = (
-    fan.fan_schema(IFan04)
-    .extend({
-        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True)
-    })
-    .extend({
-        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True)
-    })
-    .extend({
-        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True)
-    })
-    .extend(uart.UART_DEVICE_SCHEMA)
+# Fixed: Use cv.COMPONENT_SCHEMA instead of fan.fan_schema since IFan04 is not a Fan
+CONFIG_SCHEMA = cv.All(
+    cv.COMPONENT_SCHEMA.extend({
+        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),
+    }).extend(uart.UART_DEVICE_SCHEMA)
 )
 
-
 async def to_code(config):
-    var = await fan.new_fan(config)
+    var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
@@ -45,4 +39,3 @@ async def to_code(config):
         await automation.build_automation(
             var.get_buzzer_trigger(), [], config[CONF_ON_BUZZER]
         )
-

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -15,9 +15,15 @@ CONF_ON_BUZZER = "on_buzzer"
 
 CONFIG_SCHEMA = (
     fan.fan_schema(IFan04)
-    .extend(cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True))
-    .extend(cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True))
-    .extend(cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True))
+    .extend({
+        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True)
+    })
+    .extend({
+        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True)
+    })
+    .extend({
+        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True)
+    })
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -13,12 +13,13 @@ CONF_ON_FAN = "on_fan"
 CONF_ON_LIGHT = "on_light"
 CONF_ON_BUZZER = "on_buzzer"
 
-CONFIG_SCHEMA = ({
+CONFIG_SCHEMA = (
     fan.fan_schema(IFan04)
-    cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
-    cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
-    cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),
-}).extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True))
+    .extend(cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True))
+    .extend(cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.components import fan, uart
 
 DEPENDENCIES = ['uart']
+
 
 ifan04_ns = cg.esphome_ns.namespace('ifan04')
 IFan04 = ifan04_ns.class_('IFan04', cg.Component, uart.UARTDevice)
@@ -13,17 +13,23 @@ CONF_ON_FAN = "on_fan"
 CONF_ON_LIGHT = "on_light"
 CONF_ON_BUZZER = "on_buzzer"
 
-# Fixed: Use cv.COMPONENT_SCHEMA instead of fan.fan_schema since IFan04 is not a Fan
-CONFIG_SCHEMA = cv.All(
-    cv.COMPONENT_SCHEMA.extend({
-        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
-        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
-        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),
-    }).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    fan.fan_schema(IFan04)
+    .extend({
+        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True)
+    })
+    .extend({
+        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True)
+    })
+    .extend({
+        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True)
+    })
+    .extend(uart.UART_DEVICE_SCHEMA)
 )
 
+
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await fan.new_fan(config)
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
@@ -39,3 +45,4 @@ async def to_code(config):
         await automation.build_automation(
             var.get_buzzer_trigger(), [], config[CONF_ON_BUZZER]
         )
+

--- a/components/ifan04/__init__.py
+++ b/components/ifan04/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import fan, uart
+from esphome.components import uart
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ['uart']
-
 
 ifan04_ns = cg.esphome_ns.namespace('ifan04')
 IFan04 = ifan04_ns.class_('IFan04', cg.Component, uart.UARTDevice)
@@ -13,23 +13,15 @@ CONF_ON_FAN = "on_fan"
 CONF_ON_LIGHT = "on_light"
 CONF_ON_BUZZER = "on_buzzer"
 
-CONFIG_SCHEMA = (
-    fan.fan_schema(IFan04)
-    .extend({
-        cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True)
-    })
-    .extend({
-        cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True)
-    })
-    .extend({
-        cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True)
-    })
-    .extend(uart.UART_DEVICE_SCHEMA)
-)
-
+# Reverted to the original working schema - cv.COMPONENT_SCHEMA without fan.fan_schema
+CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend({
+    cv.Optional(CONF_ON_FAN): automation.validate_automation(single=True),
+    cv.Optional(CONF_ON_LIGHT): automation.validate_automation(single=True),
+    cv.Optional(CONF_ON_BUZZER): automation.validate_automation(single=True),
+}).extend(uart.UART_DEVICE_SCHEMA)
 
 async def to_code(config):
-    var = await fan.new_fan(config)
+    var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
@@ -45,4 +37,3 @@ async def to_code(config):
         await automation.build_automation(
             var.get_buzzer_trigger(), [], config[CONF_ON_BUZZER]
         )
-


### PR DESCRIPTION
On the original implementation from Sonoff, the medium speed have both relays 1 and 2 on HIGH, which makes sense, as those two have the same capacitance. With the previous implementation (only relay 2 HIGH) there's no difference between speed low and speed medium, as the capacitors and therefore the resulting voltage are the same when only relay 1 or only relay 2.